### PR TITLE
자동 이름 생성 + 바로 이동

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "korean-name-generator": "^1.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -11710,6 +11711,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/korean-name-generator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/korean-name-generator/-/korean-name-generator-1.0.4.tgz",
+      "integrity": "sha512-iIxlar4KRYg+wVsfDs6HIrAD8Z4UkCPtIzINckNXzE4paABXYDZQx4GeTA4YxU6zHxD9d+WLS7NdykqzKj/8Xw=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
@@ -25646,6 +25652,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
       "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
+    },
+    "korean-name-generator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/korean-name-generator/-/korean-name-generator-1.0.4.tgz",
+      "integrity": "sha512-iIxlar4KRYg+wVsfDs6HIrAD8Z4UkCPtIzINckNXzE4paABXYDZQx4GeTA4YxU6zHxD9d+WLS7NdykqzKj/8Xw=="
     },
     "language-subtag-registry": {
       "version": "0.3.22",

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "korean-name-generator": "^1.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,52 +2,22 @@ import "./App.css";
 import io from "socket.io-client";
 import { useState, useEffect } from "react";
 import Chat from "./Chat";
+import namer from "korean-name-generator";
 
 const socket = io.connect("http://localhost:3001");
 
 function App() {
-  const [username, setUsername] = useState("");
-  const [room, setRoom] = useState("");
   const [showChat, setShowChat] = useState(false);
-
-  const joinRoom = () => {
-    if (username !== "" && room !== "") {
-      socket.emit("join_room", room);
-      setShowChat(true);
-    }
-  };
-
-  // useEffect(() => {
-  //   // make name emit, 백에서 이름 만들기 프론트로 다시 보내기
-  //   socket.emit("create_name"); //
-  //   socket.on("receive_name", (name) => {
-  //     setUsername(name);
-  //   });
-  // }, []);
-
+  const settledRoom = "1";
+  const generatedUserName = namer.generate(true);
+  useEffect(() => {
+    socket.emit("join_room", settledRoom);
+    setShowChat(true);
+  }, []);
   return (
     <div className="App">
-      {!showChat ? (
-        <div className="joinChatContainer">
-          <h3>Join A Chat</h3>
-          <input
-            type="text"
-            placeholder="John..."
-            onChange={(event) => {
-              setUsername(event.target.value);
-            }}
-          />
-          <input
-            type="text"
-            placeholder="Room ID..."
-            onChange={(event) => {
-              setRoom(event.target.value);
-            }}
-          />
-          <button onClick={joinRoom}>Join A Room</button>
-        </div>
-      ) : (
-        <Chat socket={socket} username={username} room={room} />
+      {showChat && (
+        <Chat socket={socket} username={generatedUserName} room={settledRoom} />
       )}
     </div>
   );


### PR DESCRIPTION
korean name generator 라이브러리 활용해서 
이름 생성후에 바로 접속 가능하도록 변경했습니다.

말씀해주신 https://nickname.hwanmoo.kr/ api는 
해당 서비스에서 cors정책을 해주지 않아서 
사용을 하기 어렵습니다.

그래서 korean name generator라이브러리로 대체했습니다.
뒤의 생성된 이름 + hash값추가해주면 같은 이름이 생성되더라도 
더 많은 익명의 유저를 구분되게 할 수 있을 것 같습니다.

궁금하신 사항 있으시면 디코로 dm주세요!